### PR TITLE
Transactional support and tracking(open and click) implementation

### DIFF
--- a/CRM/Admin/Form/Setting/Sparkpost.php
+++ b/CRM/Admin/Form/Setting/Sparkpost.php
@@ -142,7 +142,7 @@ class CRM_Admin_Form_Setting_Sparkpost extends CRM_Admin_Form_Setting {
           'target' => CRM_Utils_System::url('civicrm/sparkpost/callback', NULL, TRUE, NULL, FALSE, TRUE),
           'auth_type' => 'none',
           // Just bounce-related events as click and open tracking are still done by CiviCRM
-          'events' => array('bounce', 'spam_complaint', 'policy_rejection'),
+          'events' => array('bounce', 'spam_complaint', 'policy_rejection', 'open', 'click'),
         );
         // Has this webhook already been created?
         $webhook_id = FALSE;

--- a/CRM/Sparkpost/Page/callback.php
+++ b/CRM/Sparkpost/Page/callback.php
@@ -63,9 +63,9 @@ class CRM_Sparkpost_Page_callback extends CRM_Core_Page {
     $elements = json_decode($postdata);
 
     foreach ($elements as $element) {
-      if ($element->msys && ($event = $element->msys->message_event)) {
+      if ($element->msys && (($event = $element->msys->message_event) || ($event = $element->msys->track_event))) {
         // Sanity checks
-        if ( !in_array($event->type, array('bounce', 'spam_complaint', 'policy_rejection'))
+        if ( !in_array($event->type, array('bounce', 'spam_complaint', 'policy_rejection', 'open', 'click'))
              || ($event->campaign_id && ($event->campaign_id != CRM_Sparkpost::getSetting('campaign')))
              || (!$event->rcpt_meta || !($civimail_bounce_id = $event->rcpt_meta->{'X-CiviMail-Bounce'}))
            ) {
@@ -77,9 +77,9 @@ class CRM_Sparkpost_Page_callback extends CRM_Core_Page {
         $dao->domain_id  = CRM_Core_Config::domainID();
         $dao->is_default = TRUE;
         if ( $dao->find(true) ) {
-          $rpRegex = '/^' . preg_quote($dao->localpart) . '(b|c|e|o|r|u)\.(\d+)\.(\d+)\.([0-9a-f]{16})/';
+          $rpRegex = '/^' . preg_quote($dao->localpart) . '(b|c|e|o|r|u|m)\.(\d+)\.(\d+)\.([0-9a-f]{16})/';
         } else {
-          $rpRegex = '/^(b|c|e|o|r|u)\.(\d+)\.(\d+)\.([0-9a-f]{16})/';
+          $rpRegex = '/^(b|c|e|o|r|u|m)\.(\d+)\.(\d+)\.([0-9a-f]{16})/';
         }
         $matches = array();
         if (preg_match($rpRegex, $civimail_bounce_id, $matches)) {
@@ -99,14 +99,53 @@ class CRM_Sparkpost_Page_callback extends CRM_Core_Page {
             $params['bounce_type_id'] = CRM_Utils_Array::value('Spam', $this->_civicrm_bounce_types);
             $params['bounce_reason'] = ($event->reason ? $event->reason : 'Message has been flagged as Spam by the recipient');
           }
-          elseif ($sparkpost_bounce = CRM_Utils_Array::value($event->bounce_class, $this->_sparkpost_bounce_types)) {
+          elseif ($event->type == 'bounce') {
+            $sparkpost_bounce = CRM_Utils_Array::value($event->bounce_class, $this->_sparkpost_bounce_types);
             $params['bounce_type_id'] = CRM_Utils_Array::value($sparkpost_bounce[3], $this->_civicrm_bounce_types);
             $params['bounce_reason'] = $event->reason;
+          } 
+          elseif ($event->type == 'open' || $event->type == 'click') {
+            switch ($event->type) {
+              case 'open':
+                if ($action == 'b') {//Civi Mailing do not process as done by CiviCRM
+                  break;
+                }
+                $oe = new CRM_Mailing_Event_BAO_Opened();
+                $oe->event_queue_id = $event_queue_id;
+                $oe->time_stamp = date('YmdHis', $event->timestamp);
+                $oe->save();
+                break;
+
+              case 'click':
+                if ($action == 'b') {//Civi Mailing do not process as done by CiviCRM
+                  break;
+                }
+                $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
+                if (version_compare('4.4alpha1', CRM_Core_Config::singleton()->civiVersion) > 0) {
+                  $jobCLassName = 'CRM_Mailing_DAO_Job';
+                }
+                $tracker = new CRM_Mailing_BAO_TrackableURL();
+                $tracker->url = $event->target_link_url;
+                $tracker->mailing_id = CRM_Core_DAO::getFieldValue($jobCLassName, $job_id, 'mailing_id');
+                if (!$tracker->find(TRUE)) {
+                  $tracker->save();
+                }
+                $open = new CRM_Mailing_Event_BAO_TrackableURLOpen();
+                $open->event_queue_id = $event_queue_id;
+                $open->trackable_url_id = $tracker->id;
+                $open->time_stamp = date('YmdHis', $event->timestamp);
+                $open->save();
+                break;
+            }
           }
-          if (CRM_Utils_Array::value('bounce_type_id', $params)) {
+          if (CRM_Utils_Array::value('bounce_type_id', $params)) {  
             CRM_Mailing_Event_BAO_Bounce::create($params);
           }
-          else {
+          elseif (in_array($event->type, array(
+            'spam_complaint',
+            'policy_rejection',
+            'bounce'
+          ))) {
             // Sparkpost was not, so let CiviCRM have a go at classifying it
             $params['body'] = $event->raw_reason;
             $result = civicrm_api3('Mailing', 'event_bounce', $params);

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -155,7 +155,8 @@ class Mail_Sparkpost extends Mail {
       return;
     }
     $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
-    if (version_compare('4.4alpha1', CRM_Core_Config::singleton()->civiVersion) > 0) {
+    $civiVersion = CRM_Core_BAO_Domain::version();
+    if (version_compare('4.4alpha1', $civiVersion) > 0) {
       $jobCLassName = 'CRM_Mailing_DAO_Job';
     }
     $mailing_id = CRM_Core_DAO::getFieldValue($jobCLassName, $jobId, 'mailing_id');

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -54,8 +54,8 @@ class Mail_Sparkpost extends Mail {
 
     $request_body = array(
       'options' => array(
-        'open_tracking' => FALSE,  // This will be done by CiviCRM
-        'click_tracking' => FALSE, // ditto
+        'open_tracking' => TRUE,  // Even though this will be done by CiviCRM for bulk mailing, If we want to process transactional and to process open and click event by sparkpost
+        'click_tracking' => TRUE, // same as above
       ),
       'recipients' => array(),
     );
@@ -64,8 +64,11 @@ class Mail_Sparkpost extends Mail {
       $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("X-CiviMail-Bounce", $headers));
     } else {
       // Mark the email as transactional for SparkPost
-      $request_body['options']['transactional'] = true;
-    }
+        $request_body['options']['transactional'] = true;
+        if (CRM_Utils_Array::value('Return-Path', $headers)) {//attach metadata for transactional email
+          $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
+        }
+    } 
 
     // Capture the recipients
     $request_body['recipients'] = $this->formatRecipients($recipients);

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -69,6 +69,15 @@ class Mail_Sparkpost extends Mail {
           $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
         }
     } 
+    // Attach mailing name as campaign_id for sparkpost 
+    if (!empty($request_body['metadata'])) {
+      $metadata = explode(CRM_Core_Config::singleton()->verpSeparator, $request_body['metadata']['X-CiviMail-Bounce']); 
+      list($mailing_id, $mailing_name ) = self::getMailing($metadata[1]);
+      if ($mailing_name && $mailing_id) {
+        $request_body['campaign_id'] = $mailing_name.'( '.$mailing_id.' )';
+      }
+      
+    }
 
     // Capture the recipients
     $request_body['recipients'] = $this->formatRecipients($recipients);
@@ -132,5 +141,18 @@ class Mail_Sparkpost extends Mail {
     }
 
     return $result;
+  }
+  
+  static function getMailing($jobId) {
+    if (!$jobId) {
+      return;
+    }
+    $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
+    if (version_compare('4.4alpha1', CRM_Core_Config::singleton()->civiVersion) > 0) {
+      $jobCLassName = 'CRM_Mailing_DAO_Job';
+    }
+    $mailing_id = CRM_Core_DAO::getFieldValue($jobCLassName, $jobId, 'mailing_id');
+    $mailing_name = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing', $mailing_id, 'name');
+    return array($mailing_id, $mailing_name);
   }
 }

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -74,7 +74,11 @@ class Mail_Sparkpost extends Mail {
       $metadata = explode(CRM_Core_Config::singleton()->verpSeparator, $request_body['metadata']['X-CiviMail-Bounce']); 
       list($mailing_id, $mailing_name ) = self::getMailing($metadata[1]);
       if ($mailing_name && $mailing_id) {
-        $request_body['campaign_id'] = $mailing_name.'( '.$mailing_id.' )';
+        $request_body['campaign_id'] = $mailing_name.'('.$mailing_id.')';
+        if (strlen($request_body['campaign_id']) > 64) {
+          $mailing_name         = substr($mailing_name, 0, 64 - (strlen($mailing_id) + 4));
+          $request_body['campaign_id'] = $mailing_name.'..('.$mailing_id.')';
+        }
       }
       
     }

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -66,7 +66,10 @@ class Mail_Sparkpost extends Mail {
       // Mark the email as transactional for SparkPost
         $request_body['options']['transactional'] = true;
         if (CRM_Utils_Array::value('Return-Path', $headers)) {//attach metadata for transactional email
-          $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
+          $metadata = explode(CRM_Core_Config::singleton()->verpSeparator, CRM_Utils_Array::value("Return-Path", $headers)); 
+          if ($metadata[0] == 'm') {
+            $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
+          }
         }
     } 
     // Attach mailing name as campaign_id for sparkpost 

--- a/sparkpost.php
+++ b/sparkpost.php
@@ -47,6 +47,44 @@ function sparkpost_civicrm_install() {
   _sparkpost_civix_civicrm_install();
   // Check dependencies and display error messages
   sparkpost_check_dependencies();
+  $mailingParams = array(
+    'subject' => '***All Transactional Emails Through Sparkpost***',
+    'name' => ts('Transaction Emails Sparkpost'),
+    'url_tracking' => TRUE,
+    'forward_replies' => FALSE,
+    'auto_responder' => FALSE,
+    'open_tracking' => TRUE,
+    'is_completed' => FALSE,
+  );
+
+  //create entry in civicrm_mailing
+  $mailing = CRM_Mailing_BAO_Mailing::add($mailingParams, CRM_Core_DAO::$_nullArray);
+
+  //add entry in civicrm_mailing_job
+  $config = CRM_Core_Config::singleton();
+  if (property_exists($config, 'civiVersion')) {
+    $civiVersion = $config->civiVersion;
+  }
+  else {
+    $civiVersion = CRM_Core_BAO_Domain::version();
+  }
+  
+  $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
+  if (version_compare('4.4alpha1', $civiVersion) > 0) {
+    $jobCLassName = 'CRM_Mailing_DAO_Job';
+  }
+  
+  $changeENUM = FALSE;
+  if (version_compare('4.5alpha1', $civiVersion) > 0) {
+    $changeENUM = TRUE;
+  }
+  CRM_Core_Smarty::singleton()->assign('changeENUM', $changeENUM);
+  $saveJob = new $jobCLassName();
+  $saveJob->start_date = $saveJob->end_date = date('YmdHis');
+  $saveJob->status = 'Complete';
+  $saveJob->job_type = "Special: All transactional emails being sent through Sparkpost";
+  $saveJob->mailing_id = $mailing->id;
+  $saveJob->save();
 }
 
 /**
@@ -187,4 +225,81 @@ function sparkpost_check_dependencies($display = TRUE) {
 function sparkpost_log($message) {
   $config = CRM_Core_Config::singleton();
   file_put_contents($config->configAndLogDir . 'sparkpost_log', $message . PHP_EOL, FILE_APPEND);
+}
+
+function sparkpost_civicrm_alterMailParams(&$params, $context = NULL) {
+  if ($context != 'civimail') {//Create meta data for transactional email
+    $mail = new CRM_Mailing_DAO_Mailing();
+    $mail->subject = "***All Transactional Emails Through Sparkpost***";
+    $mail->url_tracking = TRUE;
+    $mail->forward_replies = FALSE;
+    $mail->auto_responder = FALSE;
+    $mail->open_tracking = TRUE;
+    if ($mail->find(TRUE)) {
+      $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
+      if (version_compare('4.4alpha1', CRM_Core_Config::singleton()->civiVersion) > 0) {
+        $jobCLassName = 'CRM_Mailing_DAO_Job';
+      }
+
+      if (isset($params['contact_id']) && !empty($params['contact_id'])) {//We could bring contact_id in params by customizing activity bao file
+        $contactId = CRM_Utils_Array::value('contact_id', $params);
+      } else if (isset($params['contactId']) && !empty($params['contactId'])) {//Contribution/Event confirmation
+        $contactId = CRM_Utils_Array::value('contactId', $params);
+      } else {//As last option from emall address
+        $contactId = sparkpost_targetContactId($params);
+      }
+      
+      if (!$contactId) {
+        CRM_Core_Error::backtrace('backtrace before return in sparkpost alterMailParams', TRUE);
+        CRM_Core_Error::debug_var('Contact Id not known to attach header for this transactional email by Sparkpost extension possbile duplicates email hence skiping', $params);
+        return;
+      }
+      
+      if ($contactId) {
+        $eventQueueParams = array(
+          'job_id' => CRM_Core_DAO::getFieldValue($jobCLassName, $mail->id, 'id', 'mailing_id'),
+          'contact_id' => $contactId,
+          'email_id' => CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Email', $contactId, 'id', 'contact_id'),
+        );
+        $eventQueue = CRM_Mailing_Event_BAO_Queue::create($eventQueueParams);
+        $params['returnPath'] = implode(CRM_Core_Config::singleton()->verpSeparator, array('m', $eventQueueParams['job_id'], $eventQueue->id, $eventQueue->hash));//Add m to differentiate from bulk mailing
+      }
+    }
+  }
+}
+
+/**
+ * Implementation of hook_civicrm_postEmailSend
+ */
+function sparkpost_civicrm_postEmailSend(&$params) {
+  if (!empty($params['returnPath'])) {
+    $header = explode(CRM_Core_Config::singleton()->verpSeparator, $params['returnPath']);
+    $params = array(
+      'job_id' => $header[1],
+      'event_queue_id' => $header[2],
+      'hash' => $header[3],
+    );
+    CRM_Mailing_Event_BAO_Delivered::create($params);
+  }
+}
+
+/*
+ *
+ * Function to get contact id from email
+ *
+ * @param array $params - array of mail params
+ *
+ * return contact Id
+ */
+function sparkpost_targetContactId($params) {
+  $emailParams = array( 
+    'email' => trim($params['toEmail']),
+    'version' => 3,
+    'sequential' => 1,
+  );
+  $result = civicrm_api('email', 'get', $emailParams);
+  if (!$result['is_error'] && $result['count'] == 1) {
+    $contactId = $result['values'][0]['contact_id'];
+  } 
+  return $contactId;
 }

--- a/sparkpost.php
+++ b/sparkpost.php
@@ -61,13 +61,7 @@ function sparkpost_civicrm_install() {
   $mailing = CRM_Mailing_BAO_Mailing::add($mailingParams, CRM_Core_DAO::$_nullArray);
 
   //add entry in civicrm_mailing_job
-  $config = CRM_Core_Config::singleton();
-  if (property_exists($config, 'civiVersion')) {
-    $civiVersion = $config->civiVersion;
-  }
-  else {
-    $civiVersion = CRM_Core_BAO_Domain::version();
-  }
+  $civiVersion = CRM_Core_BAO_Domain::version();
   
   $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
   if (version_compare('4.4alpha1', $civiVersion) > 0) {
@@ -237,7 +231,8 @@ function sparkpost_civicrm_alterMailParams(&$params, $context = NULL) {
     $mail->open_tracking = TRUE;
     if ($mail->find(TRUE)) {
       $jobCLassName = 'CRM_Mailing_DAO_MailingJob';
-      if (version_compare('4.4alpha1', CRM_Core_Config::singleton()->civiVersion) > 0) {
+      $civiVersion = CRM_Core_BAO_Domain::version();
+      if (version_compare('4.4alpha1', $civiVersion) > 0) {
         $jobCLassName = 'CRM_Mailing_DAO_Job';
       }
 


### PR DESCRIPTION
Can be closed previous PR as this PR has that code as well.

https://github.com/cividesk/com.cividesk.email.sparkpost/pull/20

- Create meta data for transactional email and attach to mail header
- Implement 'postEmailSend' hook so that those transactional emails will show up in successful deliveries in mailing report
- Add open and click events to listen in addition to bounce', 'spam_complaint', 'policy_rejection by web hook via API
- Enable open_tracking and click_tracking via API 
- Handle track events (open and click) for transactional email in call back
- Attach campaign_id as mailing name