### PR TITLE
sparkpost_civicrm_check: correct version check function (critical for 5.0)

### DIFF
--- a/sparkpost.php
+++ b/sparkpost.php
@@ -142,8 +142,9 @@ function sparkpost_civicrm_check(&$messages) {
   $sparkpost_messages = sparkpost_check_dependencies(FALSE);
 
   // We need to add the severity (only for 4.7+)
-  $info = civicrmVersion();
-  if (version_compare($info['version'], '4.7') >= 0) {
+  $version = CRM_Utils_System::version();
+
+  if (version_compare($version, '4.7') >= 0) {
     foreach ($sparkpost_messages as &$message) {
       $message->setLevel(5); // Cannot use \Psr\Log\LogLevel::CRITICAL as this is not in 4.6 code base
     }


### PR DESCRIPTION
In 5.0, the global function `checkVersion()`  cannot be called anymore, or at least, the template is not always loaded, so the function is not defined.

When accessing the CiviCRM dashboard, I had a fatal error: `Error: Call to undefined function civicrmVersion() in sparkpost_civicrm_check() (line 171 of sparkpost.php)`.

This PR replaces it by `CRM_Utils_System::version()`.