### PR TITLE
Fix #62 - curl errors with PHP7.0

### DIFF
--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -41,7 +41,7 @@ class CRM_Sparkpost {
       // Reset HTTP request method to GET as it might have been changed to POST or DELETE
       // cf. https://stackoverflow.com/questions/4163865/how-to-reset-curlopt-customrequest
       curl_setopt(self::$ch, CURLOPT_HTTPGET, TRUE);
-      curl_setopt(self::$ch, CURLOPT_CUSTOMREQUEST, NULL);
+      curl_setopt(self::$ch, CURLOPT_CUSTOMREQUEST, "GET");
     }
     return self::$ch;
   }

--- a/info.xml
+++ b/info.xml
@@ -13,13 +13,14 @@
     <author>Cividesk</author>
     <email>info@cividesk.com</email>
   </maintainer>
-  <releaseDate>2016-05-14</releaseDate>
-  <version>1.2</version>
+  <releaseDate>2018-07-30</releaseDate>
+  <version>1.3</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>
     <ver>4.6</ver>
     <ver>4.7</ver>
+    <ver>5.0</ver>
   </compatibility>
   <comments>As always, read the documentation first! Once the extension is enabled, go to Administer &gt;&gt; System Settings &gt;&gt; Outbound Email (SparkPost) to configure and send a test email.</comments>
   <civix>


### PR DESCRIPTION
Ref https://github.com/cividesk/com.cividesk.email.sparkpost/issues/62

Need to explicitly set "GET" in CUSTOMREQUEST.

Note, I also updated the info.xml version number and date