### PR TITLE
Add option to use European sparkpost servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+*.stackdump

--- a/CRM/Admin/Form/Setting/Sparkpost.php
+++ b/CRM/Admin/Form/Setting/Sparkpost.php
@@ -38,10 +38,12 @@ class CRM_Admin_Form_Setting_Sparkpost extends CRM_Admin_Form_Setting {
     // Check dependencies and display error messages
     sparkpost_check_dependencies();
 
+	$this->addYesNo('sparkpost_EU', ts('Is your account is declared in Europe?'));
     $this->add('password', 'sparkpost_apiKey', ts('API Key'), '', TRUE);
     $this->add('text', 'sparkpost_ipPool', ts('IP pool'));
     $this->addYesNo('sparkpost_useBackupMailer', ts('Use backup mailer'));
     $this->add('text', 'sparkpost_customCallbackUrl', ts('Custom callback URL'));
+	$this->addYesNo('sparkpost_track', ts('Allow Sparkpost to track openend mails ?'));
 
     $this->_testButtonName = $this->getButtonName('refresh', 'test');
 
@@ -91,7 +93,7 @@ class CRM_Admin_Form_Setting_Sparkpost extends CRM_Admin_Form_Setting {
     CRM_Utils_System::flushCache();
 
     $formValues = $this->controller->exportValues($this->_name);
-    foreach (array('sparkpost_apiKey', 'sparkpost_ipPool', 'sparkpost_useBackupMailer', 'sparkpost_customCallbackUrl') as $name) {
+    foreach (array('sparkpost_apiKey', 'sparkpost_ipPool', 'sparkpost_useBackupMailer', 'sparkpost_customCallbackUrl', 'sparkpost_track', 'sparkpost_EU') as $name) {
       CRM_Sparkpost::setSetting($name, $formValues[$name]);
     }
 
@@ -116,11 +118,19 @@ class CRM_Admin_Form_Setting_Sparkpost extends CRM_Admin_Form_Setting {
 
       // Test that the sending domain is correctly configured
       $domain = substr(strrchr($domainEmailAddress, "@"), 1);
+	  $is_EU = CRM_Sparkpost::getSetting('sparkpost_EU');
+	  if ($is_EU) {
+		$sp_domaine = "eu.sparkpost.com";
+	  }
+	  else {
+		$sp_domaine = "sparkpost.com";
+	  }
+      
       try {
         $response = CRM_Sparkpost::call("sending-domains/$domain");
       } catch (Exception $e) {
         if (strpos($e->getMessage(), 'Invalid request') !== FALSE) {
-          $url = "https://app.sparkpost.com/account/sending-domains";
+          $url = "https://app." . $sp_domaine . "/account/sending-domains";
           CRM_Core_Session::setStatus(ts('Domain %1 is not created and not verified in Sparkpost. Please follow instructions at <a href="%2">%2</a>.',
             array(1 => $domain, 2 => $url)), ts('SparkPost error'), 'error');
           return;
@@ -131,7 +141,7 @@ class CRM_Admin_Form_Setting_Sparkpost extends CRM_Admin_Form_Setting {
         }
       }
       if (!$response->results || !$response->results->status || !$response->results->status->ownership_verified) {
-        $url = 'https://app.sparkpost.com/account/sending-domains';
+        $url = "https://app." . $sp_domaine . "/account/sending-domains";
         CRM_Core_Session::setStatus(ts('The domain \'%1\' is not verified. Please follow instructions at <a href="%2">%2</a>.',
           array(1 => $domain, 2 => $url)), ts('SparkPost error'), 'errors');
         return;

--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -42,9 +42,11 @@ class CRM_Sparkpost {
     // Start with the default values for settings
     $settings = array(
       'sparkpost_useBackupMailer' => false,
+	  'sparkpost_track' => false,
+	  'sparkpost_EU' => false,
     );
     // Merge the settings defined in DB (no more groups in 4.7, so has to be one by one ...)
-    foreach (array('sparkpost_apiKey', 'sparkpost_useBackupMailer', 'sparkpost_campaign', 'sparkpost_ipPool', 'sparkpost_customCallbackUrl') as $name) {
+    foreach (array('sparkpost_apiKey', 'sparkpost_useBackupMailer', 'sparkpost_campaign', 'sparkpost_ipPool', 'sparkpost_customCallbackUrl', 'sparkpost_track', 'sparkpost_EU' ) as $name) {
       $value = CRM_Core_BAO_Setting::getItem(CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS, $name);
       if (!is_null($value)) {
         $settings[$name] = $value;
@@ -81,8 +83,15 @@ class CRM_Sparkpost {
     }
 
     // Initialize connection and set headers
+	$is_EU = CRM_Sparkpost::getSetting('sparkpost_EU');
+	if ($is_EU) {
+		$sp_domaine = "eu.sparkpost.com";
+	}
+	else {
+		$sp_domaine = "sparkpost.com";
+	}
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, "https://api.sparkpost.com/api/v1/$path");
+    curl_setopt($ch, CURLOPT_URL, "https://api." . $sp_domaine ."/api/v1/" . $path);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
     $request_headers = array();
     $request_headers[] = 'Content-Type: application/json';
@@ -152,7 +161,7 @@ class CRM_Sparkpost {
             throw new Exception("Sparkpost error: Sending limits exceeded. Check your limits in the Sparkpost console.", CRM_Sparkpost::FALLBACK);
         }
         // Don't have specifics, so throw a generic exception
-        throw new Exception("Sparkpost error: HTTP return code $curl_info[http_code], Sparkpost error code $error->code ($error->message: $error->description). Check https://support.sparkpost.com/customer/en/portal/articles/2140916-extended-error-codes for interpretation.");
+        throw new Exception("Sparkpost error: HTTP return code $curl_info[http_code], Sparkpost error code $error->code ($error->message: $error->description). Check https://support." . $sp_domain . "/customer/en/portal/articles/2140916-extended-error-codes for interpretation.");
       }
     }
 

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -72,12 +72,23 @@ class Mail_Sparkpost extends Mail {
     list($from, $textHeaders) = $headerElements;
 
     // Default options: do not track opens and clicks as CiviCRM does it
-    $request_body = array(
-      'options' => array(
-        'open_tracking' => FALSE,  // This will be done by CiviCRM
-        'click_tracking' => FALSE, // ditto
-      )
-    );
+	$sp_tracking = CRM_Sparkpost::getSetting('sparkpost_track');
+	if ($sp_tracking) {
+		$request_body = array(
+          'options' => array(
+          'open_tracking' => TRUE,  // This will be done by CiviCRM
+          'click_tracking' => TRUE, // ditto
+          )
+        );
+	}
+	else {
+	   	$request_body = array(
+          'options' => array(
+          'open_tracking' => FALSE,  // This will be done by CiviCRM
+          'click_tracking' => FALSE, // ditto
+          )
+        );
+	}
     // Should we send via a dedicated IP pool?
     $ip_pool = CRM_Sparkpost::getSetting('sparkpost_ipPool');
     if (!empty($ip_pool)) {

--- a/settings/Sparkpost.setting.php
+++ b/settings/Sparkpost.setting.php
@@ -4,6 +4,19 @@
  */
 
 return array(
+  'sparkpost_EU' => array(
+    'group_name' => CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS,
+    'group' => 'com.cividesk.email.sparkpost',
+    'name' => 'sparkpost_EU',
+    'type' => 'Boolean',
+    'html_type' => 'radio',
+    'default' => FALSE,
+    'add' => '4.4',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Is your account is declared in Europe?',
+    'help_text' => 'European accounts have to use *.eu.sparkpost.com',
+  ),
   'sparkpost_apiKey' => array(
     'group_name' => CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS,
     'group' => 'com.cividesk.email.sparkpost',
@@ -15,7 +28,7 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'SparkPost REST API key',
-    'help_text' => 'You can create API keys at: https://app.sparkpost.com/account/credentials',
+    'help_text' => 'You can create API keys at: https://app.sparkpost.com/account/credentials, or https://app.eu.sparkpost.com/account/credentials for european accounts',
   ),
   'sparkpost_customCallbackUrl' => array(
     'group_name' => CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS,
@@ -42,5 +55,18 @@ return array(
     'is_contact' => 0,
     'description' => 'Use backup mailer?',
     'help_text' => 'The backup mailer will be used if Sparkpost cannot send emails (unverified sending domain, sending limits exceeded, ...).',
+  ),
+  'sparkpost_track' => array(
+    'group_name' => CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS,
+    'group' => 'com.cividesk.email.sparkpost',
+    'name' => 'sparkpost_track',
+    'type' => 'Boolean',
+    'html_type' => 'radio',
+    'default' => FALSE,
+    'add' => '4.4',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Allow Sparkpost to track opened mails ?',
+    'help_text' => 'Allow to track activities of transactionnal mails',
   ),
 );

--- a/templates/CRM/Admin/Form/Setting/Sparkpost.tpl
+++ b/templates/CRM/Admin/Form/Setting/Sparkpost.tpl
@@ -8,6 +8,13 @@
         <fieldset>
             <legend>{ts}SparkPost Configuration{/ts}</legend>
             <table class="form-layout-compressed">
+				<tr class="crm-sparkpost-form-block-sparkpost_EU">
+                    <td class="label">{$form.sparkpost_EU.label}</td>
+                    <td>{$form.sparkpost_EU.html}<br  />
+                        <span class="description">{ts}Is your account is declared in Europe?{/ts}
+                        </span>
+                    </td>
+                </tr>
                 <tr class="crm-sparkpost-form-block-sparkpost_apiKey">
                     <td class="label">{$form.sparkpost_apiKey.label}</td>
                     <td>{$form.sparkpost_apiKey.html}<br  />
@@ -34,6 +41,13 @@
                     <td class="label">{$form.sparkpost_customCallbackUrl.label}</td>
                     <td>{$form.sparkpost_customCallbackUrl.html}<br  />
                         <span class="description">{ts 1=$smtpURL}A custom callback URL is useful when your site is behind a proxy (like CiviProxy). Leave this blank to use the default URL.{/ts}
+                        </span>
+                    </td>
+                </tr>
+				<tr class="crm-sparkpost-form-block-sparkpost_track">
+                    <td class="label">{$form.sparkpost_track.label}</td>
+                    <td>{$form.sparkpost_track.html}<br  />
+                        <span class="description">{ts}Allow Sparkpost to track opened mails ?{/ts}
                         </span>
                     </td>
                 </tr>


### PR DESCRIPTION
Add an option to use domain eu.sparkpost.com (european acounts).
Add also an option to allow Sparkpost tracking. Usefull to track transactional mails.