### PR TITLE
#68 Don't show empty error msg for an expected workflow

### DIFF
--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -151,8 +151,12 @@ class CRM_Sparkpost {
           case 420 :
             throw new Exception("Sparkpost error: Sending limits exceeded. Check your limits in the Sparkpost console.", CRM_Sparkpost::FALLBACK);
         }
-        // Don't have specifics, so throw a generic exception
-        throw new Exception("Sparkpost error: HTTP return code $curl_info[http_code], Sparkpost error code $error->code ($error->message: $error->description). Check https://support.sparkpost.com/customer/en/portal/articles/2140916-extended-error-codes for interpretation.");
+        //If we don't get an error code OR description, this error is a 404 response for checking the suppression list for an email that isn't on it. See https://developers.sparkpost.com/api/suppression-list/#suppression-list-get-retrieve-a-suppression
+        //In that case it's an expected workflow and we don't want to return a blank error response to the user just for checking
+        if (property_exists($error, 'code') && property_exists($error, 'description')) {
+          // Don't have specifics, so throw a generic exception
+          throw new Exception("Sparkpost error: HTTP return code $curl_info[http_code], Sparkpost error code $error->code ($error->message: $error->description). Check https://support.sparkpost.com/customer/en/portal/articles/2140916-extended-error-codes for interpretation.");
+        }
       }
     }
 


### PR DESCRIPTION
Behavior is documented in the issue: Users see a blank error message for a 404 response. It looks like this happens if CiviCRM tries to delete the email on the suppression list but it's not on the suppression list and the 404 is an expected response (see https://developers.sparkpost.com/api/suppression-list/#suppression-list-get-retrieve-a-suppression).

It seems like a reasonably workflow that this check could get run if an email was put on-hold previously from the CiviCRM side, but the email was not on the Sparkpost suppression list, and gets taken off-hold by a user-submitted form or something like that. In this case we wouldn't want to show the user an error message.

This PR adds a check for a valid code and response from Sparkpost before throwing a generic error to avoid showing users blank errors for expected workflows.