### PR TITLE
Typo in Exception call

### DIFF
--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -122,7 +122,7 @@ class CRM_Sparkpost {
     }
     $data = curl_exec($ch);
     if (curl_errno($ch)) {
-      throw new Exception('Sparkpost curl error: ', curl_error($ch));
+      throw new Exception('Sparkpost curl error: '. curl_error($ch));
     }
     $curl_info = curl_getinfo($ch);
     curl_close($ch);


### PR DESCRIPTION
Syntax error for string concat when generating an exception. Previously would give:
```
Error: Wrong parameters for Exception([string $message [, long $code [, Throwable $previous = NULL]]]) in Exception->__construct() (line 113 of /home/myuser/public_html/sites/all/extensions/com.cividesk.email.sparkpost/CRM/Sparkpost.php).
```
