### PR TITLE
Update Settings handling to be standard practice for 4.7 and onwards …

### DIFF
--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -27,18 +27,15 @@ class CRM_Sparkpost {
   // Indicates we need to try sending emails out through an alternate method
   const FALLBACK = 1;
 
-  static function setSetting($setting, $value) {
+  public static function setSetting($setting, $value) {
     // Encrypt API key before storing in database
     if ($setting == 'sparkpost_apiKey') {
       $value = CRM_Utils_Crypt::encrypt($value);
     }
-    return CRM_Core_BAO_Setting::setItem(
-      $value,
-      CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS,
-      $setting);
+    return Civi::settings()->set($setting, $value);
   }
 
-  static function getSetting($setting = NULL) {
+  public static function getSetting($setting = NULL) {
     // Start with the default values for settings
     $settings = array(
       'sparkpost_useBackupMailer' => false,
@@ -46,7 +43,7 @@ class CRM_Sparkpost {
     );
     // Merge the settings defined in DB (no more groups in 4.7, so has to be one by one ...)
     foreach (array('sparkpost_apiKey', 'sparkpost_useBackupMailer', 'sparkpost_campaign', 'sparkpost_ipPool', 'sparkpost_customCallbackUrl', 'sparkpost_host' ) as $name) {
-      $value = CRM_Core_BAO_Setting::getItem(CRM_Sparkpost::SPARKPOST_EXTENSION_SETTINGS, $name);
+      $value = Civi::settings()->get($name);
       if (!is_null($value)) {
         $settings[$name] = $value;
       }
@@ -56,7 +53,8 @@ class CRM_Sparkpost {
     // And finaly returm what was asked for ...
     if (!empty($setting)) {
       return CRM_Utils_Array::value($setting, $settings);
-    } else {
+    }
+    else {
       return $settings;
     }
   }
@@ -80,7 +78,7 @@ class CRM_Sparkpost {
    *
    * @see https://developers.sparkpost.com/api/
    */
-  static function call($path, $params = array(), $content = array()) {
+  public static function call($path, $params = array(), $content = array()) {
     // Get the API key from the settings
     $authorization = CRM_Sparkpost::getSetting('sparkpost_apiKey');
     if (empty($authorization)) {

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -32,19 +32,19 @@ require_once 'Mail/RFC822.php';
 class Mail_Sparkpost extends Mail {
   // Variables used to redirect outgoing email to a backup mailer
   var $backupMailer;
-  static $unavailable = false; // static because each hook_alterMailer creates a different mailer object
+  static $unavailable = FALSE; // static because each hook_alterMailer creates a different mailer object
 
   /**
    * Sets a backup mailer
    */
-  function setBackupMailer($mailer) {
+  public function setBackupMailer($mailer) {
     $this->backupMailer = $mailer;
   }
 
   /**
    * Send an email
    */
-  function send($recipients, $headers, $body) {
+  public function send($recipients, $headers, $body) {
     if (defined('CIVICRM_MAIL_LOG')) {
       CRM_Utils_Mail::logger($recipients, $headers, $body);
       if(!defined('CIVICRM_MAIL_LOG_AND SEND')) {
@@ -105,7 +105,7 @@ class Mail_Sparkpost extends Mail {
     } catch (Exception $e) {
       if ($e->getCode() == CRM_Sparkpost::FALLBACK) {
         // Let's redirect this and all further sends to the backup mailer
-        Mail_Sparkpost::$unavailable = true;
+        Mail_Sparkpost::$unavailable = TRUE;
         return $this->send($recipients, $headers, $body);
       }
       return new PEAR_Error($e->getMessage());
@@ -122,7 +122,7 @@ class Mail_Sparkpost extends Mail {
    * @return array
    *   An array of recipients in the format that the SparkPost API expects.
    */
-  function formatRecipients($recipients) {
+  public function formatRecipients($recipients) {
     // CiviCRM passes the recipients as an array of string, each string potentially containing
     // multiple addresses in either abbreviated or full RFC822 format, e.g.
     // $recipients:

--- a/info.xml
+++ b/info.xml
@@ -13,13 +13,12 @@
     <author>Cividesk</author>
     <email>info@cividesk.com</email>
   </maintainer>
-  <releaseDate>2018-11-27</releaseDate>
-  <version>1.3</version>
+  <releaseDate>2020-05-07</releaseDate>
+  <version>1.4</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.4</ver>
-    <ver>4.6</ver>
     <ver>4.7</ver>
+    <ver>5.19</ver>
   </compatibility>
   <comments>As always, read the documentation first! Once the extension is enabled, go to Administer &gt;&gt; System Settings &gt;&gt; Outbound Email (SparkPost) to configure and send a test email.</comments>
   <civix>


### PR DESCRIPTION
…and clean up some coding style

@nganivet this primarily updates the settings setting and retrieving to be standard as per https://docs.civicrm.org/dev/en/latest/framework/setting/#domain-settings It also just makes some minor code style fixes such as including visibility statements on fuctions. It also bumps up the version number as well