### PR TITLE
Fix for issue 105: adding bounce tracking for transactional emails

### DIFF
--- a/CRM/Sparkpost.php
+++ b/CRM/Sparkpost.php
@@ -174,4 +174,44 @@ class CRM_Sparkpost {
     // Return (valid) response
     return $response;
   }
+  
+  /**
+   * Creates the special Mailing for tracking transactional emails
+   *
+   * @return Boolean
+   *   True if the mailing was created.
+   */
+  public static function createTransactionalMailing() {
+    $result = civicrm_api3('Mailing', 'get', [
+      'name' => 'Sparkpost Transactional Emails',
+    ]);
+
+    if (empty($result['values'])) {
+      // Create entry in civicrm_mailing
+      $mailingParams = [
+        'subject' => E::ts('Sparkpost Transactional Emails (do not delete)'),
+        'name' => 'Sparkpost Transactional Emails',
+        'url_tracking' => TRUE,
+        'forward_replies' => FALSE,
+        'auto_responder' => FALSE,
+        'open_tracking' => TRUE,
+        'is_completed' => FALSE,
+      ];
+
+      $mailing = CRM_Mailing_BAO_Mailing::add($mailingParams);
+
+      // Add entry in civicrm_mailing_job
+      $saveJob = new CRM_Mailing_DAO_MailingJob();
+      $saveJob->start_date = $saveJob->end_date = date('YmdHis');
+      $saveJob->status = 'Complete';
+      $saveJob->job_type = "Special: All Sparkpost transactional emails";
+      $saveJob->mailing_id = $mailing->id;
+      $saveJob->save();
+
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
 }

--- a/Mail/Sparkpost.php
+++ b/Mail/Sparkpost.php
@@ -90,6 +90,15 @@ class Mail_Sparkpost extends Mail {
     } else {
       // Mark the email as transactional for SparkPost
       $request_body['options']['transactional'] = true;
+
+      // Attach metadata for transactional email
+      if (CRM_Utils_Array::value('Return-Path', $headers)) {
+        $metadata = explode(CRM_Core_Config::singleton()->verpSeparator, CRM_Utils_Array::value("Return-Path", $headers));
+        if ($metadata[0] == 'm') {
+          $request_body['metadata'] = array('X-CiviMail-Bounce' => CRM_Utils_Array::value("Return-Path", $headers));
+        }
+      }
+
     }
 
     // Capture the recipients


### PR DESCRIPTION
This is a fix for #105 for adding the ability to track bounce mails for transactional emails. 